### PR TITLE
Modify MCP servers to accept multiple items

### DIFF
--- a/site/App.tsx
+++ b/site/App.tsx
@@ -85,6 +85,7 @@ export default function Home() {
         <Sidebar variant="floating" collapsible="icon">
           <AppSidebar onPageClicked={setPage} />
         </Sidebar>
+
         <main className="w-full flex-1">
           <SidebarTrigger className="absolute top-2 right-2" />
           <div className="h-full pr-8">{mainContent}</div>


### PR DESCRIPTION
In order to reduce tool use calls, make sure that every operation that can provide an item (i.e. get-entities-by-prefix) to also provide a list of items. This allows an LLM to save tool calls, which on Ollama in particular is important because we cannot parallelize tool calls, it can only issue a single tool call at a time
