### PR TITLE
Refactor Websockets to be a class

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "module": "./src/index.ts",
   "type": "module",
   "scripts": {
-    "lint": "eslint && tsc && prettier --check .",
+    "lint": "tsc && eslint && prettier --check .",
     "fix": "eslint --fix && prettier --write .",
     "build:all": "bun run build:vite && bun run build:server",
     "build:server": "bun build --target bun --compile --outfile ./dist/server ./server/index.ts",

--- a/server/eval-framework.ts
+++ b/server/eval-framework.ts
@@ -17,7 +17,6 @@ import { HassEventBase, HassServices } from 'home-assistant-js-websocket'
 import {
   CallServiceOptions,
   extractNotifiers,
-  fetchHAUserInformation,
   HassState,
   HomeAssistantApi,
 } from './lib/ha-ws-api'
@@ -151,8 +150,10 @@ class EvalHomeAssistantApi implements HomeAssistantApi {
 
   async sendNotification(
     target: string,
-    _message: string,
-    _title: string | undefined
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    message: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    title: string | undefined
   ): Promise<void> {
     const svcs = await this.fetchServices()
     const notifiers = await extractNotifiers(svcs)
@@ -164,7 +165,8 @@ class EvalHomeAssistantApi implements HomeAssistantApi {
 
   async callService<T = any>(
     options: CallServiceOptions,
-    _testModeOverride?: boolean
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    testModeOverride?: boolean
   ): Promise<T | null> {
     // In test mode, validate that entity_id starts with domain
     const entityId = options.target?.entity_id
@@ -191,14 +193,9 @@ export function createDefaultMockedTools(llm: LargeLanguageProvider) {
   const api = new EvalHomeAssistantApi()
 
   return [
-    createNotifyServer(null, {
-      mockFetchServices: async () => mockServices as unknown as HassServices,
-      mockFetchUsers: async () => fetchHAUserInformation(null),
-      mockSendNotification: async () => {},
-    }),
-    createHomeAssistantServer(null, llm, {
+    createNotifyServer(api),
+    createHomeAssistantServer(api, llm, {
       testMode: true,
-      mockFetchStates: async () => mockStates,
     }),
   ]
 }

--- a/server/eval-framework.ts
+++ b/server/eval-framework.ts
@@ -4,7 +4,7 @@ import {
   ANTHROPIC_EVAL_MODEL,
   AnthropicLargeLanguageProvider,
 } from './anthropic'
-import { firstValueFrom, lastValueFrom, toArray } from 'rxjs'
+import { firstValueFrom, lastValueFrom, NEVER, Observable, toArray } from 'rxjs'
 import { LargeLanguageProvider } from './llm'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { asyncMap } from '@anaisbetts/commands'
@@ -13,8 +13,14 @@ import debug from 'debug'
 
 import mockServices from '../mocks/services.json'
 import mockStates from '../mocks/states.json'
-import { HassServices } from 'home-assistant-js-websocket'
-import { fetchHAUserInformation } from './lib/ha-ws-api'
+import { HassEventBase, HassServices } from 'home-assistant-js-websocket'
+import {
+  CallServiceOptions,
+  extractNotifiers,
+  fetchHAUserInformation,
+  HassState,
+  HomeAssistantApi,
+} from './lib/ha-ws-api'
 import { createHomeAssistantServer } from './mcp/home-assistant'
 import { GradeResult, ScenarioResult } from '../shared/types'
 import { OllamaLargeLanguageProvider } from './ollama'
@@ -130,12 +136,64 @@ export async function runScenario(
  * Tools
  */
 
+class EvalHomeAssistantApi implements HomeAssistantApi {
+  fetchServices(): Promise<HassServices> {
+    return Promise.resolve(mockServices as unknown as HassServices)
+  }
+
+  fetchStates(): Promise<HassState[]> {
+    return Promise.resolve(mockStates as unknown as HassState[])
+  }
+
+  eventsObservable(): Observable<HassEventBase> {
+    return NEVER
+  }
+
+  async sendNotification(
+    target: string,
+    _message: string,
+    _title: string | undefined
+  ): Promise<void> {
+    const svcs = await this.fetchServices()
+    const notifiers = await extractNotifiers(svcs)
+
+    if (!notifiers.find((n) => n.name === target)) {
+      throw new Error('Target not found')
+    }
+  }
+
+  async callService<T = any>(
+    options: CallServiceOptions,
+    _testModeOverride?: boolean
+  ): Promise<T | null> {
+    // In test mode, validate that entity_id starts with domain
+    const entityId = options.target?.entity_id
+
+    if (entityId) {
+      // Handle both string and array cases
+      const entities = Array.isArray(entityId) ? entityId : [entityId]
+
+      for (const entity of entities) {
+        if (!entity.startsWith(`${options.domain}.`)) {
+          throw new Error(
+            `Entity ID ${entity} doesn't match domain ${options.domain}`
+          )
+        }
+      }
+    }
+
+    return null
+  }
+}
+
 export function createDefaultMockedTools(llm: LargeLanguageProvider) {
   d('Creating default mocked tools')
+  const api = new EvalHomeAssistantApi()
+
   return [
     createNotifyServer(null, {
       mockFetchServices: async () => mockServices as unknown as HassServices,
-      mockFetchUsers: async () => fetchHAUserInformation(null, { mockStates }),
+      mockFetchUsers: async () => fetchHAUserInformation(null),
       mockSendNotification: async () => {},
     }),
     createHomeAssistantServer(null, llm, {

--- a/server/lib/ha-ws-api.test.ts
+++ b/server/lib/ha-ws-api.test.ts
@@ -1,150 +1,153 @@
 import { describe, expect, it, jest } from 'bun:test'
 import { Connection } from 'home-assistant-js-websocket'
-import { callService, connectToHAWebsocket, fetchServices } from './ha-ws-api'
+import { LiveHomeAssistantApi } from './ha-ws-api'
 
-describe('the fetch methods', () => {
-  it('can fetch the services list', async () => {
-    const conn = await connectToHAWebsocket()
-    const svcs = await fetchServices(conn)
+describe('LiveHomeAssistantApi', () => {
+  describe('fetchServices method', () => {
+    it('can fetch the services list', async () => {
+      // This test uses a real Home Assistant connection
+      // Should be skipped or mocked for CI environments
+      const api = await LiveHomeAssistantApi.createViaEnv()
+      const svcs = await api.fetchServices()
 
-    console.log('Services:', svcs.notify)
-    expect(svcs).toBeDefined()
-  })
-})
-
-describe('callService function', () => {
-  it('should correctly format and send service call message', async () => {
-    // Create mock connection
-    const mockSendMessagePromise = jest
-      .fn()
-      .mockResolvedValue({ result: 'success' })
-    const mockConnection = {
-      sendMessagePromise: mockSendMessagePromise,
-    } as unknown as Connection
-
-    // Call the function
-    await callService(mockConnection, {
-      domain: 'light',
-      service: 'turn_on',
-      service_data: {
-        color_name: 'beige',
-        brightness: '101',
-      },
-      target: {
-        entity_id: 'light.kitchen',
-      },
-      return_response: true,
-    })
-
-    // Verify correct message was sent
-    expect(mockSendMessagePromise).toHaveBeenCalledWith({
-      type: 'call_service',
-      domain: 'light',
-      service: 'turn_on',
-      service_data: {
-        color_name: 'beige',
-        brightness: '101',
-      },
-      target: {
-        entity_id: 'light.kitchen',
-      },
-      return_response: true,
+      console.log('Services:', svcs.notify)
+      expect(svcs).toBeDefined()
     })
   })
 
-  it('should validate entity ID domain in test mode', async () => {
-    const mockConnection = {
-      sendMessagePromise: jest.fn(),
-    } as unknown as Connection
+  describe('callService method', () => {
+    it('should correctly format and send service call message', async () => {
+      // Create mock connection
+      const mockSendMessagePromise = jest
+        .fn()
+        .mockResolvedValue({ result: 'success' })
+      const mockConnection = {
+        sendMessagePromise: mockSendMessagePromise,
+      } as unknown as Connection
 
-    // Valid entity ID that starts with the domain
-    const result = await callService(
-      mockConnection,
-      {
+      // Create the API instance with the mock connection
+      const api = new LiveHomeAssistantApi(mockConnection)
+
+      // Call the method
+      await api.callService({
+        domain: 'light',
+        service: 'turn_on',
+        service_data: {
+          color_name: 'beige',
+          brightness: '101',
+        },
+        target: {
+          entity_id: 'light.kitchen',
+        },
+        return_response: true,
+      })
+
+      // Verify correct message was sent
+      expect(mockSendMessagePromise).toHaveBeenCalledWith({
+        type: 'call_service',
+        domain: 'light',
+        service: 'turn_on',
+        service_data: {
+          color_name: 'beige',
+          brightness: '101',
+        },
+        target: {
+          entity_id: 'light.kitchen',
+        },
+        return_response: true,
+      })
+    })
+
+    it('should validate entity ID domain in test mode', async () => {
+      const mockConnection = {
+        sendMessagePromise: jest.fn(),
+      } as unknown as Connection
+
+      // Create the API instance with test mode enabled
+      const api = new LiveHomeAssistantApi(mockConnection, true)
+
+      // Valid entity ID that starts with the domain
+      const result = await api.callService({
         domain: 'light',
         service: 'turn_on',
         target: {
           entity_id: 'light.kitchen',
         },
-      },
-      true
-    )
+      })
 
-    // Should pass validation and return null
-    expect(result).toBeNull()
-    // Should not call sendMessagePromise in test mode
-    expect(mockConnection.sendMessagePromise).not.toHaveBeenCalled()
-  })
+      // Should pass validation and return null
+      expect(result).toBeNull()
+      // Should not call sendMessagePromise in test mode
+      expect(mockConnection.sendMessagePromise).not.toHaveBeenCalled()
+    })
 
-  it('should throw error for invalid entity ID in test mode', async () => {
-    const mockConnection = {
-      sendMessagePromise: jest.fn(),
-    } as unknown as Connection
+    it('should throw error for invalid entity ID in test mode', async () => {
+      const mockConnection = {
+        sendMessagePromise: jest.fn(),
+      } as unknown as Connection
 
-    // Entity ID that doesn't match the domain
-    expect(
-      callService(
-        mockConnection,
-        {
+      // Create the API instance with test mode enabled
+      const api = new LiveHomeAssistantApi(mockConnection, true)
+
+      // Entity ID that doesn't match the domain
+      expect(
+        api.callService({
           domain: 'light',
           service: 'turn_on',
           target: {
             entity_id: 'switch.kitchen',
           },
-        },
-        true
-      )
-    ).rejects.toThrow("Entity ID switch.kitchen doesn't match domain light")
+        })
+      ).rejects.toThrow("Entity ID switch.kitchen doesn't match domain light")
 
-    // Should not call sendMessagePromise when validation fails
-    expect(mockConnection.sendMessagePromise).not.toHaveBeenCalled()
-  })
+      // Should not call sendMessagePromise when validation fails
+      expect(mockConnection.sendMessagePromise).not.toHaveBeenCalled()
+    })
 
-  it('should handle array of entity IDs in test mode', async () => {
-    const mockConnection = {
-      sendMessagePromise: jest.fn(),
-    } as unknown as Connection
+    it('should handle array of entity IDs in test mode', async () => {
+      const mockConnection = {
+        sendMessagePromise: jest.fn(),
+      } as unknown as Connection
 
-    // Valid array of entity IDs that all start with the domain
-    const result = await callService(
-      mockConnection,
-      {
+      // Create the API instance with test mode enabled
+      const api = new LiveHomeAssistantApi(mockConnection, true)
+
+      // Valid array of entity IDs that all start with the domain
+      const result = await api.callService({
         domain: 'light',
         service: 'turn_on',
         target: {
           entity_id: ['light.kitchen', 'light.living_room'],
         },
-      },
-      true
-    )
+      })
 
-    // Should pass validation and return null
-    expect(result).toBeNull()
-    // Should not call sendMessagePromise in test mode
-    expect(mockConnection.sendMessagePromise).not.toHaveBeenCalled()
-  })
+      // Should pass validation and return null
+      expect(result).toBeNull()
+      // Should not call sendMessagePromise in test mode
+      expect(mockConnection.sendMessagePromise).not.toHaveBeenCalled()
+    })
 
-  it('should throw error for mixed valid/invalid entity IDs in test mode', async () => {
-    const mockConnection = {
-      sendMessagePromise: jest.fn(),
-    } as unknown as Connection
+    it('should throw error for mixed valid/invalid entity IDs in test mode', async () => {
+      const mockConnection = {
+        sendMessagePromise: jest.fn(),
+      } as unknown as Connection
 
-    // Array with one valid and one invalid entity ID
-    expect(
-      callService(
-        mockConnection,
-        {
+      // Create the API instance with test mode enabled
+      const api = new LiveHomeAssistantApi(mockConnection, true)
+
+      // Array with one valid and one invalid entity ID
+      expect(
+        api.callService({
           domain: 'light',
           service: 'turn_on',
           target: {
             entity_id: ['light.kitchen', 'switch.porch'],
           },
-        },
-        true
-      )
-    ).rejects.toThrow("Entity ID switch.porch doesn't match domain light")
+        })
+      ).rejects.toThrow("Entity ID switch.porch doesn't match domain light")
 
-    // Should not call sendMessagePromise when validation fails
-    expect(mockConnection.sendMessagePromise).not.toHaveBeenCalled()
+      // Should not call sendMessagePromise when validation fails
+      expect(mockConnection.sendMessagePromise).not.toHaveBeenCalled()
+    })
   })
 })

--- a/server/lib/ha-ws-api.ts
+++ b/server/lib/ha-ws-api.ts
@@ -45,7 +45,24 @@ const cache = new LRUCache<string, any>({
   ttlAutopurge: false,
 })
 
-export class LiveHomeAssistantApi {
+export interface HomeAssistantApi {
+  fetchServices(): Promise<HassServices>
+  fetchStates(): Promise<HassState[]>
+  eventsObservable(): Observable<HassEventBase>
+  fetchHAUserInformation(): Promise<Record<string, HAPersonInformation>>
+  sendNotification(
+    target: string,
+    message: string,
+    title: string | undefined
+  ): Promise<void>
+
+  callService<T = any>(
+    options: CallServiceOptions,
+    testModeOverride?: boolean
+  ): Promise<T | null>
+}
+
+export class LiveHomeAssistantApi implements HomeAssistantApi {
   constructor(
     private connection: Connection,
     private testMode: boolean = false

--- a/server/llm.ts
+++ b/server/llm.ts
@@ -1,7 +1,6 @@
 import { MessageParam } from '@anthropic-ai/sdk/resources/index.mjs'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { AnthropicLargeLanguageProvider } from './anthropic'
-import { Connection as HAConnection } from 'home-assistant-js-websocket'
 import { createHomeAssistantServer } from './mcp/home-assistant'
 import { createNotifyServer } from './mcp/notify'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
@@ -10,6 +9,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { OllamaLargeLanguageProvider } from './ollama'
 import { OpenAILargeLanguageProvider } from './openai'
 import { Observable } from 'rxjs'
+import { HomeAssistantApi } from './lib/ha-ws-api'
 
 export interface LargeLanguageProvider {
   executePromptWithTools(
@@ -40,15 +40,15 @@ export function createDefaultLLMProvider() {
 }
 
 export function createBuiltinServers(
-  connection: HAConnection,
+  api: HomeAssistantApi,
   llm: LargeLanguageProvider,
   opts?: { testMode?: boolean }
 ) {
   const { testMode } = opts ?? {}
 
   return [
-    createNotifyServer(connection, { testMode: testMode ?? false }),
-    createHomeAssistantServer(connection, llm, { testMode: testMode ?? false }),
+    createNotifyServer(api),
+    createHomeAssistantServer(api, llm, { testMode: testMode ?? false }),
   ]
 }
 

--- a/server/ollama.ts
+++ b/server/ollama.ts
@@ -1,4 +1,3 @@
-import { Connection as HAConnection } from 'home-assistant-js-websocket'
 import { createNotifyServer } from './mcp/notify'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import pkg from '../package.json'
@@ -16,6 +15,7 @@ import { Ollama, Message, Tool } from 'ollama'
 import { createHomeAssistantServer } from './mcp/home-assistant'
 import { LargeLanguageProvider } from './llm'
 import { from, map, Observable } from 'rxjs'
+import { HomeAssistantApi } from './lib/ha-ws-api'
 
 const d = debug('ha:llm')
 
@@ -162,15 +162,15 @@ export class OllamaLargeLanguageProvider implements LargeLanguageProvider {
 }
 
 export function createBuiltinServers(
-  connection: HAConnection,
+  api: HomeAssistantApi,
   llm: LargeLanguageProvider,
   opts?: { testMode?: boolean }
 ) {
   const { testMode } = opts ?? {}
 
   return [
-    createNotifyServer(connection, { testMode: testMode ?? false }),
-    createHomeAssistantServer(connection, llm, { testMode: testMode ?? false }),
+    createNotifyServer(api),
+    createHomeAssistantServer(api, llm, { testMode: testMode ?? false }),
   ]
 }
 


### PR DESCRIPTION
This PR makes the Home Assistant Websocket API a class, which makes it way easier to mock it when we start in Eval mode
